### PR TITLE
Bug reproduction - link to new page

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -29,8 +29,8 @@ module.exports = {
                 link: '/docs/',
             },
             {
-                text: 'Start',
-                link: '/docs/',
+                text: 'New page',
+                link: '/docs/new3.html',
             },
             {
                 text: 'NetlifyCMS Config Help',

--- a/docs/new3.md
+++ b/docs/new3.md
@@ -1,0 +1,1 @@
+New page, will link in nav


### PR DESCRIPTION
trying to reproduce that checklinks fails when a PR includes a new page and a link to that new page

First deploy of this PR was just the new page - [commit](https://github.com/klavavej/bug-repro-checklinks/pull/3/commits/e850eb576c47785689c5e2319bd9f09807330d70) and [successful deploy](https://app.netlify.com/sites/epic-lovelace-9557e9/deploys/603926e1fcba630007fefe54)

Second deploy includes link to the new page - surprised by [successful deploy](https://app.netlify.com/sites/epic-lovelace-9557e9/deploys/6039277eb604870007c12369)